### PR TITLE
Change the wording used on the PayPal's pop-up

### DIFF
--- a/scripts/ee_pp_smart_buttons.js
+++ b/scripts/ee_pp_smart_buttons.js
@@ -215,6 +215,10 @@ function EegPayPalSmartButtons(instance_vars, translations) {
                 disallowed: []
             },
 
+            // Change the wording on the PayPal popup
+            // See: https://github.com/paypal/paypal-checkout/issues/554
+            commit: true,
+
             // PayPal Client IDs - replace with your own
             // Create a PayPal app: https://developer.paypal.com/developer/applications/create
 


### PR DESCRIPTION
Currently, if you use PayPal smart buttons and open up PayPal to make a payment you'll see a 'continue' button with some text below it showing:

> You’ll be able to review your order before you complete your purchase

No payment review is shown after logging in, if you click continue you'll be directed back to the site with the payment complete.

I did some digging and found this:

https://github.com/paypal/paypal-checkout/issues/554

## Bug report or feature request?
* [ ] Bug
* [ ] Feature
* [x] Neither


## Steps to Reproduce (for bugs)
Make a payment using this payment method, select paypal, view the popup.

## Expected Behaviour
Changes the button to show 'Pay now' and removes the ticket referring to reviewing the payment.

## Related Information:
Screenshot of how this should now display - http://take.ms/sEjxp