### PR TITLE
Dont override paypal default funding methods

### DIFF
--- a/payment_methods/Paypal_Smart_Buttons/EEG_Paypal_Smart_Buttons.gateway.php
+++ b/payment_methods/Paypal_Smart_Buttons/EEG_Paypal_Smart_Buttons.gateway.php
@@ -173,7 +173,7 @@ class EEG_Paypal_Smart_Buttons extends EE_Onsite_Gateway
             $payment->set_details($e->getTraceAsString());
             $this->log(
                 array(
-                    'error_message' => $e->getTrace(),
+                    'error_message' => $e->getMessage(),
                     'error_trace' => $e->getTraceAsString(),
                     'billing_info' => $billing_info
                 ),

--- a/scripts/ee_pp_smart_buttons.js
+++ b/scripts/ee_pp_smart_buttons.js
@@ -203,21 +203,8 @@ function EegPayPalSmartButtons(instance_vars, translations) {
                 shape: this.button_shape,      // pill | rect
             },
 
-            // Specify allowed and disallowed funding sources
-            //
-            // Options:
-            // - paypal.FUNDING.CARD
-            // - paypal.FUNDING.CREDIT
-            // - paypal.FUNDING.ELV
-
-            funding: {
-                allowed: [paypal.FUNDING.CARD, paypal.FUNDING.CREDIT],
-                disallowed: []
-            },
-
             // PayPal Client IDs - replace with your own
             // Create a PayPal app: https://developer.paypal.com/developer/applications/create
-
             client: {
                 sandbox: this.client_id,
                 production: this.client_id


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
https://github.com/eventespresso/eea-paypal-smart-buttons/issues/19#issuecomment-423152122
Don't tell PayPal which funding methods to specifically allow or disallow, just use PayPal's defaults.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [ ] when making a USD payment from Canada or USA, PayPal credit should still be an option, as well as credit cards Visa, Mastercard, Discove and American Express
* [ ] when making a USD payment from Europe, PayPal credit shouldn't be an option

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
