### PR TITLE
Pull the payment from PayPal and use the data from that

### DIFF
--- a/assets/src/ee-paypal-smart-buttons.js
+++ b/assets/src/ee-paypal-smart-buttons.js
@@ -246,15 +246,14 @@ function EegPayPalSmartButtons( instanceVars, translations ) {
 				this.hiddenInputPaymentId.val( authData.paymentID );
 				this.hiddenInputPaymentToken.val( authData.paymentToken );
 				this.hiddeIinputOrderId.val( authData.orderID );
-                // now pull the payment from PayPal and set payment_id and payer_id as they are required for the payment
-                var eePpSmartButtonsObject = this;
-                return actions.payment.get()
-                    .then(function (paymentDetails) {
-                      eePpSmartButtonsObject.hidden_input_payer_id.val(paymentDetails.payer.payer_info.payer_id);
-                      eePpSmartButtonsObject.hidden_input_payment_id.val(paymentDetails.id);
-                      // submit as now we should definitely have all of the required details
-                      eePpSmartButtonsObject.next_button.trigger('click');
-                });
+				// now pull the payment from PayPal and set payment_id and payer_id as they are required for the payment
+				return actions.payment.get()
+					.then( function( paymentDetails ) {
+						eePpSmartButtonsObject.hidden_input_payer_id.val( paymentDetails.payer.payer_info.payer_id );
+						eePpSmartButtonsObject.hidden_input_payment_id.val( paymentDetails.id );
+						// submit as now we should definitely have all of the required details
+						eePpSmartButtonsObject.next_button.trigger( 'click' );
+				});
 			},
 			onError: ( errorData ) => {
 				let error = null;

--- a/assets/src/ee-paypal-smart-buttons.js
+++ b/assets/src/ee-paypal-smart-buttons.js
@@ -245,11 +245,15 @@ function EegPayPalSmartButtons( instanceVars, translations ) {
 				this.hiddenInputPaymentId.val( authData.paymentID );
 				this.hiddenInputPaymentToken.val( authData.paymentToken );
 				this.hiddeIinputOrderId.val( authData.orderID );
-				// Wait a second before submitting in order to avoid accidentally submitting before the values were updated.
-				setTimeout( () => {
-					this.nextButton.trigger( 'click' );
-				},
-				1000 );
+                // now pull the payment from PayPal and set payment_id and payer_id as they are required for the payment
+                var eePpSmartButtonsObject = this;
+                return actions.payment.get()
+                    .then(function (paymentDetails) {
+                      eePpSmartButtonsObject.hidden_input_payer_id.val(paymentDetails.payer.payer_info.payer_id);
+                      eePpSmartButtonsObject.hidden_input_payment_id.val(paymentDetails.id);
+                      // submit as now we should definitely have all of the required details
+                      eePpSmartButtonsObject.next_button.trigger('click');
+                });
 			},
 			onError: ( errorData ) => {
 				let error = null;

--- a/assets/src/ee-paypal-smart-buttons.js
+++ b/assets/src/ee-paypal-smart-buttons.js
@@ -240,6 +240,7 @@ function EegPayPalSmartButtons( instanceVars, translations ) {
 			},
 
 			onAuthorize: ( authData, actions ) => {
+				let eePpSmartButtonsObject = this;
 				// don't execute the payment here. Let's do it server-side where it's more secure
 				this.hiddenInputPayerId.val( authData.payerID );
 				this.hiddenInputPaymentId.val( authData.paymentID );

--- a/assets/src/ee-paypal-smart-buttons.js
+++ b/assets/src/ee-paypal-smart-buttons.js
@@ -239,7 +239,7 @@ function EegPayPalSmartButtons( instanceVars, translations ) {
 				} );
 			},
 
-			onAuthorize: ( authData ) => {
+			onAuthorize: ( authData, actions ) => {
 				// don't execute the payment here. Let's do it server-side where it's more secure
 				this.hiddenInputPayerId.val( authData.payerID );
 				this.hiddenInputPaymentId.val( authData.paymentID );


### PR DESCRIPTION
Hey @mnelson4,

I hope you don't mind as this is a bit out of the blue, when we started getting reports of the payer_id error I started doing a little digging into it and notice a few different examples used this method to get the details so I gave it a go and so far... payments work as expected and if I'm right in how I think this works, should 'wait' until we have the details needed before it submits.

So first, please feel free to drop this PR if you don't want to use it, I'm certainly no JS master this is just what I ended up with from when I started looking at it as a side project.

Just to run through how I think this now works:

In this branch, rather than just using the paymentToken data (named authData in this version) and hopefully setting the details before triggering the button click, this branch uses those details and sets everything you did previously but then pulls the payment from PayPal again and uses the values we need from that.

`actions.payment.get()` pulls the payment, but this time you get a payment object so don't have all of the same details, however, you do get the payment_id and payer_id which appear to be the only values that are actually used anyway?

So in short, this uses all the values it used to, but then pulls the payment and re-sets the payment_id and payer_id fields from the payment.... then if that was successful, triggers the click.

I'm pretty sure that if we don't get a payment back from PayPal, the button won't click... but at the same time that likely means that the request would fail on the next step anyway, right?

## How has this been tested
**NOT USING THE BUILD PROCESS**, truth be told have no idea how to run it. 

So I've just manually added this into `/src/ee-paypal-smart-buttons.js` after doing all my testing using the version just before this.

Tested by just running through the usual payment process and confirming it still works, I've also commented out the code that sets the values from authData and used just my new code, that worked too.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
