### PR TITLE
ADD: filters for PayPalSmartButtons eePpSmartButtonsData orderDescription

### DIFF
--- a/payment_methods/Paypal_Smart_Buttons/forms/PayPalSmartButtonBillingForm.php
+++ b/payment_methods/Paypal_Smart_Buttons/forms/PayPalSmartButtonBillingForm.php
@@ -168,15 +168,15 @@ class PayPalSmartButtonBillingForm extends EE_Billing_Info_Form
                     'no_SPCO_error' => esc_html__('It appears the Single Page Checkout javascript was not loaded properly! Please refresh the page and try again or contact support.', 'event_espresso'),
                     'no_paypal_js' => esc_html__('It appears the Paypal Express Checkout javascript was not loaded properly! Please refresh the page and try again or contact support.', 'event_espresso'),
                     'orderDescription' => apply_filters('EventEspresso_PayPalSmartButtons_payment_methods_Paypal_Smart_Buttons_forms_PayPalSmartButtonBillingForm__enqueue_js__eePpSmartButtonsData__translations__orderDescription', sprintf(
-                            // translators: 1: event name, 2: site name
-                            esc_html_x(
-                                'Event Registrations for %1$s from %2$s',
-                                'Event Registrations for Event Name from Site Name',
-                                "event_espresso"
-                            ),
-                            $event_name,
-                            wp_specialchars_decode(get_bloginfo(), ENT_QUOTES)
-                        ), $event_name, $this->transaction, $this->_pm_instance, $this->registry ),
+                        // translators: 1: event name, 2: site name
+                        esc_html_x(
+                            'Event Registrations for %1$s from %2$s',
+                            'Event Registrations for Event Name from Site Name',
+                            "event_espresso"
+                        ),
+                        $event_name,
+                        wp_specialchars_decode(get_bloginfo(), ENT_QUOTES)
+                    ), $event_name, $this->transaction, $this->_pm_instance, $this->registry)
                 ]
             ]
         );

--- a/payment_methods/Paypal_Smart_Buttons/forms/PayPalSmartButtonBillingForm.php
+++ b/payment_methods/Paypal_Smart_Buttons/forms/PayPalSmartButtonBillingForm.php
@@ -167,16 +167,16 @@ class PayPalSmartButtonBillingForm extends EE_Billing_Info_Form
                 'translations' => [
                     'no_SPCO_error' => esc_html__('It appears the Single Page Checkout javascript was not loaded properly! Please refresh the page and try again or contact support.', 'event_espresso'),
                     'no_paypal_js' => esc_html__('It appears the Paypal Express Checkout javascript was not loaded properly! Please refresh the page and try again or contact support.', 'event_espresso'),
-                    'orderDescription' => sprintf(
-                        // translators: 1: event name, 2: site name
-                        esc_html_x(
-                            'Event Registrations for %1$s from %2$s',
-                            'Event Registrations for Event Name from Site Name',
-                            "event_espresso"
-                        ),
-                        $event_name,
-                        wp_specialchars_decode(get_bloginfo(), ENT_QUOTES)
-                    ),
+                    'orderDescription' => apply_filters('EventEspresso_PayPalSmartButtons_payment_methods_Paypal_Smart_Buttons_forms_PayPalSmartButtonBillingForm__enqueue_js__eePpSmartButtonsData__translations__orderDescription', sprintf(
+                            // translators: 1: event name, 2: site name
+                            esc_html_x(
+                                'Event Registrations for %1$s from %2$s',
+                                'Event Registrations for Event Name from Site Name',
+                                "event_espresso"
+                            ),
+                            $event_name,
+                            wp_specialchars_decode(get_bloginfo(), ENT_QUOTES)
+                        ), $event_name, $this->transaction, $this->_pm_instance, $this->registry ),
                 ]
             ]
         );

--- a/payment_methods/Paypal_Smart_Buttons/forms/PayPalSmartButtonBillingForm.php
+++ b/payment_methods/Paypal_Smart_Buttons/forms/PayPalSmartButtonBillingForm.php
@@ -161,13 +161,13 @@ class PayPalSmartButtonBillingForm extends EE_Billing_Info_Form
                     'hiddenInputPaymentTokenSelector' => '#ee-paypal-payment-token',
                     'hiddenInputOrderIdSelector' => '#ee-paypal-order-id',
                     //phpcs:disable Generic.Files.LineLength.TooLong
-                    'shipping' => apply_filters('EventEspresso_PayPalSmartButtons_payment_methods_Paypal_Smart_Buttons_forms_PayPalSmartButtonBillingForm__enqueue_js__eePpSmartButtonsData__data__shipping', 'NO_SHIPPING', $this->transaction)
+                    'shipping' => apply_filters('FHEE__PayPalSmartButtonBillingForm__enqueue_js__eePpSmartButtonsData__data__shipping', 'NO_SHIPPING', $this->transaction)
                     //phpcs:enable
                 ],
                 'translations' => [
                     'no_SPCO_error' => esc_html__('It appears the Single Page Checkout javascript was not loaded properly! Please refresh the page and try again or contact support.', 'event_espresso'),
                     'no_paypal_js' => esc_html__('It appears the Paypal Express Checkout javascript was not loaded properly! Please refresh the page and try again or contact support.', 'event_espresso'),
-                    'orderDescription' => apply_filters('EventEspresso_PayPalSmartButtons_payment_methods_Paypal_Smart_Buttons_forms_PayPalSmartButtonBillingForm__enqueue_js__eePpSmartButtonsData__translations__orderDescription', sprintf(
+                    'orderDescription' => apply_filters('FHEE__PayPalSmartButtonBillingForm__enqueue_js__eePpSmartButtonsData__translations__orderDescription', sprintf(
                         // translators: 1: event name, 2: site name
                         esc_html_x(
                             'Event Registrations for %1$s from %2$s',


### PR DESCRIPTION
## Problem this Pull Request solves
I need to edit / customize the orderDescription for PayPalSmartButtons

## How has this been tested
I tested directly online with the real payment option for the page. I follow the filter naming on line 164 of the same if to correspond the same naming.
