### PR TITLE
set the txn_id_chq_nmbr to a value that matches in PayPal's admin

### DIFF
--- a/payment_methods/Paypal_Smart_Buttons/EEG_Paypal_Smart_Buttons.gateway.php
+++ b/payment_methods/Paypal_Smart_Buttons/EEG_Paypal_Smart_Buttons.gateway.php
@@ -153,11 +153,14 @@ class EEG_Paypal_Smart_Buttons extends EE_Onsite_Gateway
         // @todo setup the items
         try {
             $payment_id = isset($billing_info['payment_id']) ? $billing_info['payment_id'] : '';
-            $payment->set_txn_id_chq_nmbr($payment_id);
             $response_data = $this->getClient()->executePayment(
                 isset($billing_info['payer_id']) ? $billing_info['payer_id'] : '',
                 $payment_id
             );
+            $txn_sale_id = isset($response_data['transactions'][0]['related_resources'][0]['sale']['id']) 
+                ? $response_data['transactions'][0]['related_resources'][0]['sale']['id']
+                : '';
+            $payment->set_txn_id_chq_nmbr($txn_sale_id);
             $this->log(
                 array(
                     'response_data' => $response_data,

--- a/payment_methods/Paypal_Smart_Buttons/EEG_Paypal_Smart_Buttons.gateway.php
+++ b/payment_methods/Paypal_Smart_Buttons/EEG_Paypal_Smart_Buttons.gateway.php
@@ -157,7 +157,7 @@ class EEG_Paypal_Smart_Buttons extends EE_Onsite_Gateway
                 isset($billing_info['payer_id']) ? $billing_info['payer_id'] : '',
                 $payment_id
             );
-            $txn_sale_id = isset($response_data['transactions'][0]['related_resources'][0]['sale']['id']) 
+            $txn_sale_id = isset($response_data['transactions'][0]['related_resources'][0]['sale']['id'])
                 ? $response_data['transactions'][0]['related_resources'][0]['sale']['id']
                 : '';
             $payment->set_txn_id_chq_nmbr($txn_sale_id);


### PR DESCRIPTION



<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Matching a payment within an Event Espresso transaction isn't easy if the payment was made using PayPal Express with smart buttons. This PR changes the value set that's shown under "TXN ID/ CHQ #" in the Payment Details table of an Event Espresso Transaction. The new value matches what's shown as the "Transaction ID" in PayPal (and can be searched for).

See also: https://eventespresso.com/topic/transaction-id-and-locating-payments/



## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
Do a test payment using PayPal Express w/ Smart buttons. 
- [ ] Then visit the Event Espresso > Transactions page, view the transaction and copy the value under TXN ID / CHQ #
- [ ] Then log into the seller's PayPal sandbox account, and do a search for the payment using the value you just copied

![Screen Shot 2020-03-30 at 2 45 14 PM](https://user-images.githubusercontent.com/891156/77961568-090adb00-72a8-11ea-9cd4-20d300addd11.png)
![Screen Shot 2020-03-30 at 2 45 02 PM](https://user-images.githubusercontent.com/891156/77961578-0c05cb80-72a8-11ea-9e2c-169eb5ce12fa.png)


## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
